### PR TITLE
 Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/arbaro/java/net/sourceforge/arbaro/arbaro.java
+++ b/src/arbaro/java/net/sourceforge/arbaro/arbaro.java
@@ -226,7 +226,7 @@ public class arbaro {
 		else tree.readFromXML(in);
 		
 		// FIXME: put here or earlier?
-		if (smooth>=0) tree.params.setParam("Smooth",new Double(smooth).toString());
+		if (smooth>=0) tree.params.setParam("Smooth",new Double.toString(smooth));
 		
 		tree.params.verbose=(! quiet);
 		tree.params.Seed=seed;

--- a/src/arbaro/java/net/sourceforge/arbaro/export/DXFExporter.java
+++ b/src/arbaro/java/net/sourceforge/arbaro/export/DXFExporter.java
@@ -129,7 +129,7 @@ final class DXFWriter {
 	}
 	
 	void wg(int code, String val) {
-		w.println(""+code);
+		w.println(Integer.toString(code));
 		w.println(val);
 	}
 	

--- a/src/arbaro/java/net/sourceforge/arbaro/gui/CfgDialog.java
+++ b/src/arbaro/java/net/sourceforge/arbaro/gui/CfgDialog.java
@@ -223,8 +223,8 @@ public class CfgDialog {
 	
 	class OKButtonListener implements ActionListener {
 		public void actionPerformed(ActionEvent e) {
-			config.setProperty("export.format",""+formatBox.getSelectedIndex());
-			config.setProperty("export.path",""+pathField.getText());
+			config.setProperty("export.format", Integer.toString(formatBox.getSelectedIndex()));
+			config.setProperty("export.path", pathField.getText());
 			config.setProperty("povray.executable",fileField.getText());
 			config.setProperty("povray.width",widthField.getText());
 			config.setProperty("povray.height",heightField.getText());

--- a/src/arbaro/java/net/sourceforge/arbaro/gui/ParamValueTable.java
+++ b/src/arbaro/java/net/sourceforge/arbaro/gui/ParamValueTable.java
@@ -203,7 +203,7 @@ public final class ParamValueTable extends JPanel {
 			for (int i=0; i<items.length; i++) {
 				// values[i] = new Integer(i);
 				shapeIcons[i] = createImageIcon("images/shape"+i+".png",items[i]);
-				addItem(""+i);
+				addItem(Integer.toString(i));
 			}
 		}
 		
@@ -213,7 +213,7 @@ public final class ParamValueTable extends JPanel {
 		}
 		
 		public String getValue() {
-			return ""+getSelectedIndex();
+			return Integer.toString(getSelectedIndex());
 		}
 	    
 		class ShapeRenderer extends JLabel implements ListCellRenderer {

--- a/src/arbaro/java/net/sourceforge/arbaro/gui/PreviewTree.java
+++ b/src/arbaro/java/net/sourceforge/arbaro/gui/PreviewTree.java
@@ -84,7 +84,7 @@ public final class PreviewTree extends Tree {
 			// FIXME: previewTree.Levels <= tree.Levels
 			int Levels = ((IntParam)(originalParams.getParam("Levels"))).intValue(); 
 			if (Levels>showLevel+1) {
-				setParam("Levels",""+(showLevel+1));
+				setParam("Levels", Integer.toString(showLevel+1));
 				setParam("Leaves","0");
 			} 
 			for (int i=0; i<showLevel; i++) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - “Primitives should not be boxed just for "String" conversion”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.