### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/com/ryanmichela/trees/PhysicalCraftingRecipe.java
+++ b/src/main/java/com/ryanmichela/trees/PhysicalCraftingRecipe.java
@@ -35,7 +35,7 @@ public class PhysicalCraftingRecipe {
 
   public final byte[][]      data;
   public final Material[][]  pattern;
-  public final Set<Material> usedMaterials = new HashSet<Material>();
+  public final Set<Material> usedMaterials = new HashSet<>();
 
   /**
    * Creates a PhysicalCraftingRecipe from a 2D pattern of Materials. The
@@ -157,8 +157,8 @@ public class PhysicalCraftingRecipe {
     Validate.notEmpty(materialDataMap, "materialMap cannot be null or empty");
 
     // Break up materialDataMap into materialMap and dataMap
-    final Map<Character, Material> materialMap = new HashMap<Character, Material>();
-    final Map<Character, Byte> dataMap = new HashMap<Character, Byte>();
+    final Map<Character, Material> materialMap = new HashMap<>();
+    final Map<Character, Byte> dataMap = new HashMap<>();
     for (final Character c : materialDataMap.keySet()) {
       final String s = materialDataMap.get(c);
       final String[] splits = s.split(":", 2);

--- a/src/main/java/com/ryanmichela/trees/PlantTreeEventHandler.java
+++ b/src/main/java/com/ryanmichela/trees/PlantTreeEventHandler.java
@@ -59,7 +59,7 @@ public class PlantTreeEventHandler implements Listener {
       final ConfigurationSection materialsSection = patternSection.getConfigurationSection("materials");
       final Map<String, Object> configMaterialMap = materialsSection.getValues(false);
 
-      final Map<Character, String> materialDataMap = new HashMap<Character, String>();
+      final Map<Character, String> materialDataMap = new HashMap<>();
       for (final Map.Entry<String, Object> kvp : configMaterialMap.entrySet()) {
         materialDataMap.put(kvp.getKey().charAt(0), (String) kvp.getValue());
       }

--- a/src/main/java/com/ryanmichela/trees/rendering/Draw3d.java
+++ b/src/main/java/com/ryanmichela/trees/rendering/Draw3d.java
@@ -188,7 +188,7 @@ public class Draw3d {
 
   private List<Point2D> plotCircle(final int cx, final int cy, final int z,
                                    final int r, final int level) {
-    final List<Point2D> points2d = new LinkedList<Point2D>();
+    final List<Point2D> points2d = new LinkedList<>();
 
     final int rSquare = r * r;
     for (int x = -r - 8; x <= (r + 8); x++) {
@@ -207,7 +207,7 @@ public class Draw3d {
   }
 
   private List<Vector> plotDownwardHemisphere(final Vector pos, final double r) {
-    final List<Vector> points = new LinkedList<Vector>();
+    final List<Vector> points = new LinkedList<>();
     final int rCeil = (int) Math.ceil(r) + 4;
     final double r2 = r * r;
     for (int x = -rCeil; x <= rCeil; x++) {
@@ -230,7 +230,7 @@ public class Draw3d {
   private List<Vector> plotEllipsoid(final Vector pos, final double a,
                                      final double b, final double c,
                                      final int level) {
-    final List<Vector> points = new LinkedList<Vector>();
+    final List<Vector> points = new LinkedList<>();
 
     final int halfSize = (int) Math.ceil(Math.max(Math.max(a, b), c)) + 2;
 
@@ -254,7 +254,7 @@ public class Draw3d {
 
   private List<Point2D> plotLine2d(final int x1, final int y1, final int x2,
                                    final int y2) {
-    final List<Point2D> points2d = new LinkedList<Point2D>();
+    final List<Point2D> points2d = new LinkedList<>();
     // Bresenham's Line Algorithm
     int currentX, currentY;
     int xInc, yInc;
@@ -312,7 +312,7 @@ public class Draw3d {
 
   private List<Vector> plotLine3d(final Vector l1, final Vector l2,
                                   final Orientation orientation) {
-    final List<Vector> locations = new LinkedList<Vector>();
+    final List<Vector> locations = new LinkedList<>();
     if (orientation == Orientation.xMajor) /* x dominant */
     {
       final List<Point2D> xy = this.plotLine2d(l1.getBlockX(), l1.getBlockY(),
@@ -347,7 +347,7 @@ public class Draw3d {
 
   private List<Vector> plotSphere(final Vector pos, final double r,
                                   final int level) {
-    final List<Vector> points = new LinkedList<Vector>();
+    final List<Vector> points = new LinkedList<>();
     final int rCeil = (int) Math.ceil(r) + 4;
     final double r2 = r * r;
     for (int x = -rCeil; x <= rCeil; x++) {

--- a/src/main/java/com/ryanmichela/trees/rendering/JungleVinePopulator.java
+++ b/src/main/java/com/ryanmichela/trees/rendering/JungleVinePopulator.java
@@ -31,7 +31,7 @@ public class JungleVinePopulator {
     final WorldChangeKey east = new WorldChangeKey();
     final WorldChangeKey west = new WorldChangeKey();
 
-    final List<WorldChange> newChanges = new LinkedList<WorldChange>();
+    final List<WorldChange> newChanges = new LinkedList<>();
 
     for (final WorldChange change : tracker.getChanges()) {
       if ((change.material == Material.LOG)

--- a/src/main/java/com/ryanmichela/trees/rendering/WorldChangeTracker.java
+++ b/src/main/java/com/ryanmichela/trees/rendering/WorldChangeTracker.java
@@ -88,8 +88,8 @@ public class WorldChangeTracker {
   }
 
   private int                                      BLOCKS_PER_TICK;
-  private final Map<WorldChangeKey, WorldChange>   changes = new HashMap<WorldChangeKey, WorldChange>(
-                                                                                                      10000);
+  private final Map<WorldChangeKey, WorldChange>   changes = new HashMap<>(
+          10000);
   private final CraftMassBlockUpdate               massBlockUpdate;
   private final Plugin                             plugin;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.